### PR TITLE
v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v2.2.3
+- *Fixed:* Joins without `IdentifierMapping` were incorrectly generated with mapping code where the root table has mapping, and the joined table did not. The `GlobalId` JSON name can now also be renamed.
+
 ## v2.2.2
 - *Fixed:* Updated `CoreEx` (`v3.3.0`) and `DbEx` (`v2.3.6`).
 

--- a/docs/generated/table.md
+++ b/docs/generated/table.md
@@ -101,7 +101,7 @@ Provides the _identifier mapping_ configuration.
 
 Property | Description
 -|-
-**`identifierMapping`** | Indicates whether to perform Identifier Mapping (mapping to `GlobalId`) for the primary key.<br/>&dagger; This indicates whether to create a new `GlobalId` property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s). Defaults to `Root.IdentifierMapping`.
+**`identifierMapping`** | Indicates whether to perform Identifier Mapping (mapping to `GlobalId`) for the primary key.<br/>&dagger; This indicates whether to create a new `GlobalId` property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s).
 
 <br/>
 

--- a/schemas/ntangle.json
+++ b/schemas/ntangle.json
@@ -409,7 +409,12 @@
         "identifierMapping": {
           "type": "boolean",
           "title": "Indicates whether to perform Identifier Mapping (mapping to 'GlobalId') for the primary key.",
-          "description": "This indicates whether to create a new 'GlobalId' property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s). Defaults to 'Root.IdentifierMapping'."
+          "description": "This indicates whether to create a new 'GlobalId' property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s)."
+        },
+        "identifierName": {
+          "type": "string",
+          "title": "The JSON name for the 'GlobalId' property where 'IdentifierMapping' is 'true'. Defaults to 'globalId'.",
+          "description": "This indicates whether to create a new 'GlobalId' property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s)."
         },
         "isDeletedColumn": {
           "type": "string",
@@ -558,6 +563,11 @@
         "identifierMapping": {
           "type": "boolean",
           "title": "Indicates whether to perform Identifier Mapping (mapping to 'GlobalId') for the primary key.",
+          "description": "This indicates whether to create a new 'GlobalId' property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s)."
+        },
+        "identifierName": {
+          "type": "string",
+          "title": "The JSON name for the 'GlobalId' property where 'IdentifierMapping' is 'true'. Defaults to 'globalId'.",
           "description": "This indicates whether to create a new 'GlobalId' property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s)."
         },
         "on": {

--- a/src/NTangle/Config/JoinConfig.cs
+++ b/src/NTangle/Config/JoinConfig.cs
@@ -193,6 +193,14 @@ namespace NTangle.Config
            Description = "This indicates whether to create a new `GlobalId` property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s).")]
         public bool? IdentifierMapping { get; set; }
 
+        /// <summary>
+        /// Gets or sets JSON name for the `GlobalId` property where `IdentifierMapping` is `true`. Defaults to `globalId`.
+        /// </summary>
+        [JsonProperty("identifierName", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [CodeGenProperty("IdentifierName", Title = "The JSON name for the `GlobalId` property where `IdentifierMapping` is `true`. Defaults to `globalId`.", IsImportant = true,
+           Description = "This indicates whether to create a new `GlobalId` property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s).")]
+        public string? IdentifierName { get; set; }
+
         #endregion
 
         #region Collections
@@ -331,6 +339,8 @@ namespace NTangle.Config
             JoinCardinality = DefaultWhereNull(JoinCardinality, () => "OneToMany");
             CdcEnable = DefaultWhereNull(CdcEnable, () => Root.CdcEnable);
             Property = DefaultWhereNull(Property, () => JoinCardinality == "OneToMany" ? StringConverter.ToPlural(Model) : Model);
+            IdentifierMapping = DefaultWhereNull(IdentifierMapping, () => false);
+            IdentifierName = DefaultWhereNull(IdentifierName, () => "globalId");
             if (ExcludeColumnsFromETag == null && Root!.ExcludeColumnsFromETag != null)
                 ExcludeColumnsFromETag = new List<string>(Root!.ExcludeColumnsFromETag!);
 

--- a/src/NTangle/Config/TableConfig.cs
+++ b/src/NTangle/Config/TableConfig.cs
@@ -269,9 +269,16 @@ namespace NTangle.Config
         /// </summary>
         [JsonProperty("identifierMapping", DefaultValueHandling = DefaultValueHandling.Ignore)]
         [CodeGenProperty("IdentifierMapping", Title = "Indicates whether to perform Identifier Mapping (mapping to `GlobalId`) for the primary key.", IsImportant = true,
-           Description = "This indicates whether to create a new `GlobalId` property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s)." 
-            + " Defaults to `Root.IdentifierMapping`.")]
+           Description = "This indicates whether to create a new `GlobalId` property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s).")]
         public bool? IdentifierMapping { get; set; }
+
+        /// <summary>
+        /// Gets or sets JSON name for the `GlobalId` property where `IdentifierMapping` is `true`. Defaults to `globalId`.
+        /// </summary>
+        [JsonProperty("identifierName", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [CodeGenProperty("IdentifierName", Title = "The JSON name for the `GlobalId` property where `IdentifierMapping` is `true`. Defaults to `globalId`.", IsImportant = true,
+           Description = "This indicates whether to create a new `GlobalId` property on the _entity_ to house the global mapping identifier to be the reference outside of the specific database realm as a replacement to the existing primary key column(s).")]
+        public string? IdentifierName { get; set; }
 
         #endregion
 
@@ -450,6 +457,7 @@ namespace NTangle.Config
             EventType = DefaultWhereNull(EventType, () => Model);
             Database = DefaultWhereNull(Database, () => "IDatabase");
             Service = DefaultWhereNull(Service, () => Root.Service);
+            IdentifierName = DefaultWhereNull(IdentifierName, () => "globalId");
             IsDeletedColumn = DefaultWhereNull(IsDeletedColumn, () => Root!.IsDeletedColumn);
             if (ExcludeColumnsFromETag == null && Root!.ExcludeColumnsFromETag != null)
                 ExcludeColumnsFromETag = new List<string>(Root!.ExcludeColumnsFromETag!);

--- a/src/NTangle/NTangle.csproj
+++ b/src/NTangle/NTangle.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>NTangle</RootNamespace>
-    <Version>2.2.2</Version>
+    <Version>2.2.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>NTangle Developers</Authors>
     <Company>Avanade</Company>

--- a/src/NTangle/Templates/Entity_cs.hbs
+++ b/src/NTangle/Templates/Entity_cs.hbs
@@ -13,9 +13,9 @@ public partial class {{Model}}Cdc : IEntity{{#ifval ColumnConfigIsDeleted}}, ILo
 {{#if IdentifierMapping}}
     /// <inheritdoc/>
   {{#ifeq Root.JsonSerializer 'Newtonsoft'}}
-    [JsonProperty("globalId"]
+    [JsonProperty("{{IdentifierName}}"]
   {{else}}
-    [JsonPropertyName("globalId")]
+    [JsonPropertyName("{{IdentifierName}}")]
   {{/ifeq}}
     public {{Root.IdentifierMappingDotNetType}}? GlobalId { get; set; }
 
@@ -161,11 +161,13 @@ public partial class {{Model}}Cdc : IEntity{{#ifval ColumnConfigIsDeleted}}, ILo
     {{/ifval}}
   {{/each}}
   {{#each JoinCdcChildren}}
-    {{#ifeq JoinCardinality 'OneToMany'}}
+    {{#if IdentifierMapping}}
+      {{#ifeq JoinCardinality 'OneToMany'}}
         {{Property}}?.ForEach(async item => await item.LinkIdentifierMappingsAsync(coll, idGen).ConfigureAwait(false));
-    {{else}}
+      {{else}}
         await ({{Property}}?.LinkIdentifierMappingsAsync(coll, idGen) ?? Task.CompletedTask).ConfigureAwait(false);
-    {{/ifeq}}
+      {{/ifeq}}
+    {{/if}}
   {{/each}}
     }
 
@@ -181,11 +183,13 @@ public partial class {{Model}}Cdc : IEntity{{#ifval ColumnConfigIsDeleted}}, ILo
     {{/ifval}}
   {{/each}}
   {{#each JoinCdcChildren}}
-    {{#ifeq JoinCardinality 'OneToMany'}}
+    {{#if IdentifierMapping}}
+      {{#ifeq JoinCardinality 'OneToMany'}}
         {{Property}}?.ForEach(item => item.RelinkIdentifierMappings(coll));
-    {{else}}
+      {{else}}
         {{Property}}?.RelinkIdentifierMappings(coll);
-    {{/ifeq}}
+      {{/ifeq}}
+    {{/if}}
   {{/each}}
     }
 {{/if}}
@@ -201,9 +205,9 @@ public partial class {{Model}}Cdc : IEntity{{#ifval ColumnConfigIsDeleted}}, ILo
   {{#if IdentifierMapping}}
         /// <inheritdoc/>
     {{#ifeq Root.JsonSerializer 'Newtonsoft'}}
-        [JsonProperty("globalId")]
+        [JsonProperty("{{IdentifierName}}")]
     {{else}}
-        [JsonPropertyName("globalId")]
+        [JsonPropertyName("{{IdentifierName}}")]
     {{/ifeq}}
         public {{Root.IdentifierMappingDotNetType}}? GlobalId { get; set; }
 

--- a/tools/NTangle.Template/NTangle.Template.csproj
+++ b/tools/NTangle.Template/NTangle.Template.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>2.2.2</Version>
+    <Version>2.2.3</Version>
     <Authors>NTangle Developers</Authors>
     <Company>Avanade</Company>
     <Description>NTangle template solution for use with 'dotnet new'.</Description>

--- a/tools/NTangle.Template/content/AppName.CodeGen/AppName.CodeGen.csproj
+++ b/tools/NTangle.Template/content/AppName.CodeGen/AppName.CodeGen.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NTangle" Version="2.2.2" />
+    <PackageReference Include="NTangle" Version="2.2.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="ntangle.yaml">

--- a/tools/NTangle.Template/content/AppName.Database/AppName.Database.csproj
+++ b/tools/NTangle.Template/content/AppName.Database/AppName.Database.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NTangle" Version="2.2.2" />
+    <PackageReference Include="NTangle" Version="2.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/NTangle.Template/content/AppName.Publisher/AppName.Publisher.csproj
+++ b/tools/NTangle.Template/content/AppName.Publisher/AppName.Publisher.csproj
@@ -12,7 +12,7 @@
     <!--#endif -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NTangle" Version="2.2.2" />
+    <PackageReference Include="NTangle" Version="2.2.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">


### PR DESCRIPTION
- *Fixed:* Joins without `IdentifierMapping` were incorrectly generated with mapping code where the root table has mapping, and the joined table did not. The `GlobalId` JSON name can now also be renamed.