### PR TITLE
v2.3.5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
         dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
         
     - name: Restore dependencies
       run: dotnet restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v2.3.5
+- *Fixed:* Updated `DbEx` (`v2.3.13`) and`CoreEx` (`v3.6.1`) and other dependencies.
+- *Fixed:* Added `net8.0` support.
+- *Fixed:* The `EntityOrchestrator` mapping code generation for sub-classes was not always being generated correctly; non-compiling missing `,` formatting corrected.
+
 ## v2.3.4
 - *Fixed:* Updated `DbEx` (`v2.3.12`) and `CoreEx` (`v3.4.1`).
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.3.4</Version>
+    <Version>2.3.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>NTangle Developers</Authors>
     <Company>Avanade</Company>

--- a/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Database/ContactSync.NewApp.Database.csproj
+++ b/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Database/ContactSync.NewApp.Database.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.12" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.13" />
   </ItemGroup>
 
 </Project>

--- a/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Subscriber/ContactSync.NewApp.Subscriber.csproj
+++ b/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Subscriber/ContactSync.NewApp.Subscriber.csproj
@@ -26,11 +26,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>  <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.6.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.6.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.6.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.5" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Database/ContactSync.OldApp.Database.csproj
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Database/ContactSync.OldApp.Database.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.12" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.13" />
   </ItemGroup>
 
 </Project>

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/ContactSync.OldApp.Publisher.csproj
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/ContactSync.OldApp.Publisher.csproj
@@ -22,9 +22,9 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.6.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.5" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/SqlServerDemo/SqlServerDemo.Database/SqlServerDemo.Database.csproj
+++ b/samples/SqlServerDemo/SqlServerDemo.Database/SqlServerDemo.Database.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.12" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.13" />
   </ItemGroup>
 
 </Project>

--- a/samples/SqlServerDemo/SqlServerDemo.Publisher/SqlServerDemo.Publisher.csproj
+++ b/samples/SqlServerDemo/SqlServerDemo.Publisher/SqlServerDemo.Publisher.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.6.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
   </ItemGroup>
 

--- a/samples/SqlServerDemo/SqlServerDemo.Test/SqlServerDemo.Test.csproj
+++ b/samples/SqlServerDemo/SqlServerDemo.Test/SqlServerDemo.Test.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/src/NTangle/NTangle.csproj
+++ b/src/NTangle/NTangle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>NTangle</RootNamespace>
     <Product>NTangle</Product>
     <Title>NTangle Change-Data-Capture framework/runtime.</Title>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.6.1" />
     <PackageReference Include="OnRamp" Version="1.0.8" />
   </ItemGroup>
   

--- a/tests/NTangle.Test/NTangle.Test.csproj
+++ b/tests/NTangle.Test/NTangle.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/tests/NTangle.Test/TemplateTest.cs
+++ b/tests/NTangle.Test/TemplateTest.cs
@@ -108,7 +108,7 @@ namespace NTangle.Test
             // Build and package (nuget) - only local package, no deployment.
             Assert.GreaterOrEqual(0, ExecuteCommand("powershell", $"{Path.Combine(_rootDir.FullName, "nuget-publish.ps1")} -configuration 'Debug' -IncludeSymbols -IncludeSource").exitCode, "nuget publish");
 
-            // Uninstall any previous beef templates (failure is ok here)
+            // Uninstall any previous nTangle templates (failure is ok here)
             ExecuteCommand("dotnet", "new uninstall NTangle.Template");
 
             // Uninstall the template solution from local package.

--- a/tools/NTangle.CodeGen/NTangle.CodeGen.csproj
+++ b/tools/NTangle.CodeGen/NTangle.CodeGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>NTangle.CodeGen</RootNamespace>
     <Product>NTangle Code-Gen</Product>
     <Title>NTangle Change-Data-Capture code-generation.</Title>
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.4.1" />
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.12" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.6.1" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.13" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tools/NTangle.CodeGen/Templates/EntityOrchestrator_cs.hbs
+++ b/tools/NTangle.CodeGen/Templates/EntityOrchestrator_cs.hbs
@@ -187,7 +187,7 @@ public partial class {{Model}}Orchestrator : EntityOrchestrator<{{Model}}Cdc, {{
   {{/each}}
   {{#each JoinNonCdcChildren}}
       {{#each Columns}}
-            {{pascal NameAlias}} = record.GetValue<{{DotNetType}}{{#if IsDotNetNullable}}?{{/if}}>("{{pascal NameAlias}}"){{#unless @last}},{{/unless}}
+            {{pascal NameAlias}} = record.GetValue<{{DotNetType}}{{#if IsDotNetNullable}}?{{/if}}>("{{pascal NameAlias}}"){{#unless @last}},{{else}}{{#unless ../@last}},{{/unless}}{{/unless}}
       {{/each}}
   {{/each}}
         };

--- a/tools/NTangle.Template/content/AppName.Database/AppName.Database.csproj
+++ b/tools/NTangle.Template/content/AppName.Database/AppName.Database.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.8" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/NTangle.Template/content/AppName.Publisher/AppName.Publisher.csproj
+++ b/tools/NTangle.Template/content/AppName.Publisher/AppName.Publisher.csproj
@@ -12,7 +12,7 @@
     <!--#endif -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NTangle" Version="2.3.1" />
+    <PackageReference Include="NTangle" Version="2.3.5" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">
@@ -33,7 +33,7 @@
     <Folder Include="Services\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.3.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.6.1" />
     <!--#if (implement_publisher_console) -->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <!--#endif -->


### PR DESCRIPTION
- *Fixed:* Updated `DbEx` (`v2.3.13`) and`CoreEx` (`v3.6.1`) and other dependencies.
- *Fixed:* Added `net8.0` support.
- *Fixed:* The `EntityOrchestrator` mapping code generation for sub-classes was not always being generated correctly; non-compiling missing `,` formatting corrected.