### PR TITLE
v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v2.5.2
+- *Fixed:* Updated `CoreEx` (`v3.15.0`) and other dependencies.
+- *Fixed:* Simplify event outbox C# code-generation templates for primary constructor usage.
+
 ## v2.5.1
 - *Fixed:* Updated `CoreEx` (`v3.13.0`) and other dependencies.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.5.1</Version>
+    <Version>2.5.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>NTangle Developers</Authors>
     <Company>Avanade</Company>

--- a/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Database/ContactSync.NewApp.Database.csproj
+++ b/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Database/ContactSync.NewApp.Database.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.5.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Subscriber/ContactSync.NewApp.Subscriber.csproj
+++ b/samples/ContactSync/ContactSync.NewApp/ContactSync.NewApp.Subscriber/ContactSync.NewApp.Subscriber.csproj
@@ -26,11 +26,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>  <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.13.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.13.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.13.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.15.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.14.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Database/ContactSync.OldApp.Database.csproj
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Database/ContactSync.OldApp.Database.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.5.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/ContactSync.OldApp.Publisher.csproj
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/ContactSync.OldApp.Publisher.csproj
@@ -23,9 +23,9 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.13.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.15.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.14.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Data/Generated/EventOutboxDequeue.cs
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Data/Generated/EventOutboxDequeue.cs
@@ -7,16 +7,11 @@ namespace ContactSync.OldApp.Publisher.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxDequeue : EventOutboxDequeueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="eventSender">The <see cref="IEventSender"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : EventOutboxDequeueBase(database, eventSender, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxDequeue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="eventSender">The <see cref="IEventSender"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : base(database, eventSender, logger) { }
-
     /// <inheritdoc/>
     protected override string DequeueStoredProcedure => "[Outbox].[spEventOutboxDequeue]";
 }

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Data/Generated/EventOutboxEnqueue.cs
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Data/Generated/EventOutboxEnqueue.cs
@@ -7,15 +7,10 @@ namespace ContactSync.OldApp.Publisher.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxEnqueue : EventOutboxEnqueueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : EventOutboxEnqueueBase(database, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxEnqueue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : base(database, logger) { }
-
     /// <inheritdoc/>
     protected override string DbTvpTypeName => "[Outbox].[udtEventOutboxList]";
 

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Data/Generated/VersionTrackingMapper.cs
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Data/Generated/VersionTrackingMapper.cs
@@ -7,10 +7,4 @@ namespace ContactSync.OldApp.Publisher.Data;
 /// <summary>
 /// Provides the <see cref="VersionTracking"/> database mapper for table '[NTangle].[VersionTracking]'.
 /// </summary>
-public class VersionTrackingMapper : VersionTrackingMapperBase
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="VersionTrackingMapper"/> class.
-    /// </summary>
-    public VersionTrackingMapper() : base("[NTangle].[udtVersionTrackingList]") { }
-}
+public class VersionTrackingMapper() : VersionTrackingMapperBase("[NTangle].[udtVersionTrackingList]") { }

--- a/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Services/Generated/ContactService.cs
+++ b/samples/ContactSync/ContactSync.OldApp/ContactSync.OldApp.Publisher/Services/Generated/ContactService.cs
@@ -7,13 +7,7 @@ namespace ContactSync.OldApp.Publisher.Services;
 /// <summary>
 /// Provides the Change Data Capture (CDC) <see cref="ContactCdc"/> entity (aggregate root) <see cref="CdcService{TOrchestrator, TEntity}"/> capabilities (database table '[old].[Contact]').
 /// </summary>
-public partial class ContactService : CdcService<IContactOrchestrator, ContactCdc>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ContactService"/> class.
-    /// </summary>
-    /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-    public ContactService(IServiceProvider serviceProvider, ILogger<ContactService> logger, SettingsBase settings) : base(serviceProvider, logger, settings) { }
-}
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+/// <param name="settings">The <see cref="SettingsBase"/>.</param>
+public partial class ContactService(IServiceProvider serviceProvider, ILogger<ContactService> logger, SettingsBase settings) : CdcService<IContactOrchestrator, ContactCdc>(serviceProvider, logger, settings) { }

--- a/samples/SqlServerDemo/SqlServerDemo.Database/SqlServerDemo.Database.csproj
+++ b/samples/SqlServerDemo/SqlServerDemo.Database/SqlServerDemo.Database.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.5.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/EventOutboxDequeue.cs
+++ b/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/EventOutboxDequeue.cs
@@ -7,16 +7,11 @@ namespace SqlServerDemo.Publisher.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxDequeue : EventOutboxDequeueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="eventSender">The <see cref="IEventSender"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : EventOutboxDequeueBase(database, eventSender, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxDequeue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="eventSender">The <see cref="IEventSender"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxDequeue(IDatabase database, IEventSender eventSender, ILogger<EventOutboxDequeue> logger) : base(database, eventSender, logger) { }
-
     /// <inheritdoc/>
     protected override string DequeueStoredProcedure => "[Outbox].[spEventOutboxDequeue]";
 }

--- a/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/EventOutboxEnqueue.cs
+++ b/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/EventOutboxEnqueue.cs
@@ -7,15 +7,10 @@ namespace SqlServerDemo.Publisher.Data;
 /// <summary>
 /// Provides the <see cref="EventSendData"/> <see cref="IDatabase">database</see> <i>outbox enqueue</i> <see cref="SendAsync(EventSendData[])"/>. 
 /// </summary>
-public sealed class EventOutboxEnqueue : EventOutboxEnqueueBase
+/// <param name="database">The <see cref="IDatabase"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+public sealed class EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : EventOutboxEnqueueBase(database, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EventOutboxEnqueue"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="IDatabase"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public EventOutboxEnqueue(IDatabase database, ILogger<EventOutboxEnqueue> logger) : base(database, logger) { }
-
     /// <inheritdoc/>
     protected override string DbTvpTypeName => "[Outbox].[udtEventOutboxList]";
 

--- a/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/IdentifierMappingMapper.cs
+++ b/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/IdentifierMappingMapper.cs
@@ -8,10 +8,4 @@ namespace SqlServerDemo.Publisher.Data;
 /// Provides the <see cref="IdentifierMapping{T}"/> database mapper for table '[NTangle].[IdentifierMapping]'.
 /// </summary>
 /// <typeparam name="T">The global identifier <see cref="System.Type"/>.</typeparam>
-public class IdentifierMappingMapper<T> : IdentifierMappingMapperBase<T>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="VersionTrackingMapper"/> class.
-    /// </summary>
-    public IdentifierMappingMapper() : base("[NTangle].[udtIdentifierMappingList]") { }
-}
+public class IdentifierMappingMapper<T>() : IdentifierMappingMapperBase<T>("[NTangle].[udtIdentifierMappingList]") { }

--- a/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/VersionTrackingMapper.cs
+++ b/samples/SqlServerDemo/SqlServerDemo.Publisher/Data/Generated/VersionTrackingMapper.cs
@@ -7,10 +7,4 @@ namespace SqlServerDemo.Publisher.Data;
 /// <summary>
 /// Provides the <see cref="VersionTracking"/> database mapper for table '[NTangle].[VersionTracking]'.
 /// </summary>
-public class VersionTrackingMapper : VersionTrackingMapperBase
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="VersionTrackingMapper"/> class.
-    /// </summary>
-    public VersionTrackingMapper() : base("[NTangle].[udtVersionTrackingList]") { }
-}
+public class VersionTrackingMapper() : VersionTrackingMapperBase("[NTangle].[udtVersionTrackingList]") { }

--- a/samples/SqlServerDemo/SqlServerDemo.Publisher/SqlServerDemo.Publisher.csproj
+++ b/samples/SqlServerDemo/SqlServerDemo.Publisher/SqlServerDemo.Publisher.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.13.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.15.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
   </ItemGroup>
 

--- a/samples/SqlServerDemo/SqlServerDemo.Test/SqlServerDemo.Test.csproj
+++ b/samples/SqlServerDemo/SqlServerDemo.Test/SqlServerDemo.Test.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/NTangle/NTangle.csproj
+++ b/src/NTangle/NTangle.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.13.0" />
-    <PackageReference Include="OnRamp" Version="2.0.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
+    <PackageReference Include="OnRamp" Version="2.2.0" />
   </ItemGroup>
   
   <Import Project="..\..\Common.targets" />

--- a/tests/NTangle.Test/NTangle.Test.csproj
+++ b/tests/NTangle.Test/NTangle.Test.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tools/NTangle.CodeGen/NTangle.CodeGen.csproj
+++ b/tools/NTangle.CodeGen/NTangle.CodeGen.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.13.0" />
-    <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.5.1" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tools/NTangle.CodeGen/Templates/EntityService_cs.hbs
+++ b/tools/NTangle.CodeGen/Templates/EntityService_cs.hbs
@@ -8,13 +8,7 @@ namespace {{Root.NamespacePublisher}}.Services;
 /// <summary>
 /// Provides the Change Data Capture (CDC) <see cref="{{Model}}Cdc"/> entity (aggregate root) <see cref="CdcService{TOrchestrator, TEntity}"/> capabilities (database table '[{{Schema}}].[{{Name}}]').
 /// </summary>
-public partial class {{Model}}Service : CdcService<I{{Model}}Orchestrator, {{Model}}Cdc>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="{{Model}}Service"/> class.
-    /// </summary>
-    /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-    public {{Model}}Service(IServiceProvider serviceProvider, ILogger<{{Model}}Service> logger, SettingsBase settings) : base(serviceProvider, logger, settings) { }
-}
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+/// <param name="logger">The <see cref="ILogger"/>.</param>
+/// <param name="settings">The <see cref="SettingsBase"/>.</param>
+public partial class {{Model}}Service(IServiceProvider serviceProvider, ILogger<{{Model}}Service> logger, SettingsBase settings) : CdcService<I{{Model}}Orchestrator, {{Model}}Cdc>(serviceProvider, logger, settings) { }

--- a/tools/NTangle.CodeGen/Templates/IdentifierMappingMapper_cs.hbs
+++ b/tools/NTangle.CodeGen/Templates/IdentifierMappingMapper_cs.hbs
@@ -9,10 +9,4 @@ namespace {{Root.NamespacePublisher}}.Data;
 /// Provides the <see cref="IdentifierMapping{T}"/> database mapper for table '[{{Root.CdcSchema}}].[{{Root.IdentifierMappingTable}}]'.
 /// </summary>
 /// <typeparam name="T">The global identifier <see cref="System.Type"/>.</typeparam>
-public class IdentifierMappingMapper<T> : IdentifierMappingMapperBase<T>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="VersionTrackingMapper"/> class.
-    /// </summary>
-    public IdentifierMappingMapper() : base("[{{Root.CdcSchema}}].[udt{{Root.IdentifierMappingTable}}List]") { }
-}
+public class IdentifierMappingMapper<T>() : IdentifierMappingMapperBase<T>("[{{Root.CdcSchema}}].[udt{{Root.IdentifierMappingTable}}List]") { }

--- a/tools/NTangle.CodeGen/Templates/VersionTrackingMapper_cs.hbs
+++ b/tools/NTangle.CodeGen/Templates/VersionTrackingMapper_cs.hbs
@@ -8,10 +8,4 @@ namespace {{Root.NamespacePublisher}}.Data;
 /// <summary>
 /// Provides the <see cref="VersionTracking"/> database mapper for table '[{{Root.CdcSchema}}].[{{Root.VersionTrackingTable}}]'.
 /// </summary>
-public class VersionTrackingMapper : VersionTrackingMapperBase
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="VersionTrackingMapper"/> class.
-    /// </summary>
-    public VersionTrackingMapper() : base("[{{Root.CdcSchema}}].[udt{{Root.VersionTrackingTable}}List]") { }
-}
+public class VersionTrackingMapper() : VersionTrackingMapperBase("[{{Root.CdcSchema}}].[udt{{Root.VersionTrackingTable}}List]") { }

--- a/tools/NTangle.Template/content/AppName.CodeGen/AppName.CodeGen.csproj
+++ b/tools/NTangle.Template/content/AppName.CodeGen/AppName.CodeGen.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NTangle.CodeGen" Version="2.5.1" />
+    <PackageReference Include="NTangle.CodeGen" Version="2.5.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="ntangle.yaml">

--- a/tools/NTangle.Template/content/AppName.Database/AppName.Database.csproj
+++ b/tools/NTangle.Template/content/AppName.Database/AppName.Database.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/NTangle.Template/content/AppName.Publisher/AppName.Publisher.csproj
+++ b/tools/NTangle.Template/content/AppName.Publisher/AppName.Publisher.csproj
@@ -8,7 +8,7 @@
     <!--#endif -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NTangle" Version="2.5.1" />
+    <PackageReference Include="NTangle" Version="2.5.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">
@@ -29,7 +29,7 @@
     <Folder Include="Services\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.13.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.15.0" />
     <!--#if (implement_publisher_console) -->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <!--#endif -->

--- a/tools/NTangle.Template/content/AppName.Publisher/DomainNameSettings.cs
+++ b/tools/NTangle.Template/content/AppName.Publisher/DomainNameSettings.cs
@@ -3,14 +3,9 @@
 /// <summary>
 /// Provides the <b>AppName</b> settings.
 /// </summary>
-public class DomainNameSettings : SettingsBase
+/// <param name="configuration">The <see cref="IConfiguration"/>.</param>
+public class DomainNameSettings(IConfiguration configuration) : SettingsBase(configuration, "DomainName")
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DomainNameSettings"/> class.
-    /// </summary>
-    /// <param name="configuration">The <see cref="IConfiguration"/>.</param>
-    public DomainNameSettings(IConfiguration configuration) : base(configuration, "DomainName") { }
-
     /// <summary>
     /// Gets the SQL Server database connection string.
     /// </summary>

--- a/tools/NTangle.Template/content/AppName.Publisher/Functions/ContactFunction.cs
+++ b/tools/NTangle.Template/content/AppName.Publisher/Functions/ContactFunction.cs
@@ -1,10 +1,8 @@
 namespace AppName.Publisher.Functions;
 
-public class ContactFunction
+public class ContactFunction(ContactService contactService)
 {
-    private readonly ContactService _contactService;
-
-    public ContactFunction(ContactService contactService) => _contactService = contactService.ThrowIfNull();
+    private readonly ContactService _contactService = contactService.ThrowIfNull();
 
     [Function(nameof(ContactFunction))]
     public Task RunAsync([TimerTrigger("*/5 * * * * *")] TimerInfo timer, CancellationToken cancellationToken) => _contactService.ExecuteAsync(cancellationToken);

--- a/tools/NTangle.Template/content/AppName.Publisher/Functions/RelayFunction.cs
+++ b/tools/NTangle.Template/content/AppName.Publisher/Functions/RelayFunction.cs
@@ -1,10 +1,8 @@
 namespace AppName.Publisher.Functions;
 
-public class PublishFunction
+public class PublishFunction(EventOutboxService eventOutboxService)
 {
-    private readonly EventOutboxService _eventOutboxService;
-
-    public PublishFunction(EventOutboxService eventOutboxService) => _eventOutboxService = eventOutboxService.ThrowIfNull();
+    private readonly EventOutboxService _eventOutboxService = eventOutboxService.ThrowIfNull();
 
     [Function(nameof(PublishFunction))]
     public Task RunAsync([TimerTrigger("*/5 * * * * *")] TimerInfo timer, CancellationToken cancellationToken) => _eventOutboxService.ExecuteAsync(cancellationToken);


### PR DESCRIPTION
- *Fixed:* Updated `CoreEx` (`v3.15.0`) and other dependencies.
- *Fixed:* Simplify event outbox C# code-generation templates for primary constructor usage.